### PR TITLE
bring highlighting back

### DIFF
--- a/src/assets/stylesheets/prism-highlighting.scss
+++ b/src/assets/stylesheets/prism-highlighting.scss
@@ -80,7 +80,10 @@ pre[class*='language-'] {
   border-radius: 0.3em;
 }
 
-:not(pre) > code[class*='language-'],
+:not(pre) > code[class*='language-']{
+  background-color: #dbdbdb;
+}
+
 pre[class*='language-'] {
   background-color: #fdf6e3; /* base3 */
 }

--- a/src/assets/stylesheets/prism-highlighting.scss
+++ b/src/assets/stylesheets/prism-highlighting.scss
@@ -82,6 +82,8 @@ pre[class*='language-'] {
 
 :not(pre) > code[class*='language-']{
   background-color: #dbdbdb;
+  font-size: 16px;
+  color: #414141;
 }
 
 pre[class*='language-'] {

--- a/src/templates/blogTemplate.tsx
+++ b/src/templates/blogTemplate.tsx
@@ -77,7 +77,7 @@ const createRecordFromString = string => {
 const components = {
   code: ({ children, className }) => {
     if (!className) {
-      return <code>{children}</code>
+      return <code className={'language-text'}>{children}</code>
     }
 
     const [language, paramsString] = className.split(':')


### PR DESCRIPTION
### Description

Our highlighting for `<code>` component broke, after some changes

### Changes

Add classname for the code element back

### Considerations

 -- 

### Demo

<img width="821" alt="Screenshot 2023-05-25 at 06 58 56" src="https://github.com/brains-and-beards/open-brainsandbeards-com/assets/60060961/5baab9bf-1cd4-4b0b-afdd-f2beae6f5948">

