### PR TITLE
adjust styling for image

### DIFF
--- a/src/assets/stylesheets/homepage.scss
+++ b/src/assets/stylesheets/homepage.scss
@@ -135,12 +135,12 @@ section {
     padding: 0 20px;
     margin-top: -10px;
     @include tablet-version {
-      img {
+      div {
         max-width: 400px;
       }
     }
     @include desktop-version {
-      img {
+      div {
         max-width: 680px;
       }
     }
@@ -222,6 +222,10 @@ section {
 }
 
 .our-clients-left-col {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
   .left-col {
     @include tablet-version {
       width: auto;

--- a/src/components/CaseStudies/images.tsx
+++ b/src/components/CaseStudies/images.tsx
@@ -62,7 +62,12 @@ export const manomanoLogoImage = (
 )
 
 export const rakutenHeroImage = (
-  <StaticImage src="../../assets/case-studies/rakuten-team.jpg" alt="Femtasy banner" width={680} />
+  <StaticImage
+    src="../../assets/case-studies/rakuten-team.jpg"
+    alt="Femtasy banner"
+    width={680}
+    layout={'fixed'}
+  />
 )
 
 export const rakutenLogoImage = (

--- a/src/components/CaseStudies/images.tsx
+++ b/src/components/CaseStudies/images.tsx
@@ -18,6 +18,7 @@ export const femtasyHeroImage = (
     src="../../assets/case-studies/femtasy/femtasy-header.png"
     alt="Femtasy banner"
     width={680}
+    layout={'fixed'}
   />
 )
 
@@ -32,7 +33,8 @@ export const femtasyLogoImage = (
 export const lokalportalHeroImage = (
   <StaticImage
     src="../../assets/case-studies/lokalportal/lokalportal-web.jpg"
-    alt="Femtasy banner"
+    layout={'fixed'}
+    alt="lokalportal banner"
     width={680}
   />
 )
@@ -64,7 +66,7 @@ export const manomanoLogoImage = (
 export const rakutenHeroImage = (
   <StaticImage
     src="../../assets/case-studies/rakuten-team.jpg"
-    alt="Femtasy banner"
+    alt="Rakuten team"
     width={680}
     layout={'fixed'}
   />


### PR DESCRIPTION
### Description

The [issue](https://nozbe.app/teams/Xi3SI50NCpPkVxNz/task_id/UxZHfxeFXALjkCHN) is in image sizing and positioning

### Changes

adjust styles accoding to the new implementation (after the Gatsby upgrade 

### Considerations

--

### Demo

<img width="1438" alt="Screenshot 2023-05-25 at 11 48 16" src="https://github.com/brains-and-beards/open-brainsandbeards-com/assets/60060961/966d537f-1682-4e95-9202-6a00fa5e250e">

### Note!

As I understood this fix is only for one service page (out of 3) so, I'll mark this PR as a draft, and ask You to review [the page](https://deploy-preview-29--brains-and-beards-com.netlify.app/services/native-development/), and then adjust the pages are left