### PR TITLE
Add MRN redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,4 @@
 /jobs https://brains-and-beards.notion.site/Job-offers-at-Brains-Beards-1b21951978bd4a11b9b03b5fbf0021c1
 /jobs/ https://brains-and-beards.notion.site/Job-offers-at-Brains-Beards-1b21951978bd4a11b9b03b5fbf0021c1
+/mrn https://brains-beards.ck.page/maintainable-react-native
+/mrn/ https://brains-beards.ck.page/maintainable-react-native


### PR DESCRIPTION
### Description

Adds a `/mrn` redirect for the Maintainable React Native course landing page. 
